### PR TITLE
Remove unnecessary attributes from AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,4 @@
   ~ file, you can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.goterl.lazycode.lazysodium">
-    <application android:allowBackup="true"
-                 android:supportsRtl="true"/>
-</manifest>
+<manifest package="com.goterl.lazycode.lazysodium" />


### PR DESCRIPTION
A library project of this kind should not define attributes like "allowBackup" or "supportsRtl" in AndroidManifest. They are not actually needed for the library itself, but they force the consuming apps/libraries to override it with `tools:replace`.