### PR TITLE
Fix Maven repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install by adding the `jcenter()` repository. For Maven users, please see [here]
 ```groovy
 // Top level build file
 repositories {
-    jcenter()
+    maven { url 'https://dl.bintray.com/terl/lazysodium-maven' }
 }
 
 // Add to dependencies section


### PR DESCRIPTION
Only lazysodium-java is in JCenter; lazysodium-android is in its own Bintray repository. This confused me for a while when I was trying to add it as a dependency.